### PR TITLE
Add step to check type Python hints

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,5 +20,8 @@ jobs:
     - name: Install dependencies
       run: make install
 
+    - name: Check type hints
+      run: make build
+
     - name: Run tests
       run: make test


### PR DESCRIPTION
Add step to check type Python hints in Github workflow: Makefile CI