### PR TITLE
fix: out of bounds error when we given less prices

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.10.7'
 
     - name: Install dependencies
       run: make install

--- a/src/analyst/analyst.py
+++ b/src/analyst/analyst.py
@@ -64,7 +64,8 @@ def get_price_anomaly(prices: DataFrame) -> Optional[PriceAnomaly]:
 
 def _get_return_in_period(prices: DataFrame, period: Period) -> float:
     today_price = get_current_price(prices)
-    initial_row = prices.iloc[_get_trading_days(period) - 1]
+    first_row_in_period = min(len(prices), _get_trading_days(period))
+    initial_row = prices.iloc[first_row_in_period - 1]
     initial_price = ClosePrice(initial_row.Date, initial_row.Close)
     return _get_price_difference(today_price, initial_price)
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,4 +4,4 @@ yfinance==0.1.74
 python-telegram-bot==13.13
 coverage==6.4.4
 coverage-badge==1.1.0
-mypy==0.971
+mypy==0.990


### PR DESCRIPTION
To calculate the yearly return, we need to take the first and last rows of the dataframe. Previously we are taking the last row as `prices[252-1]`, which caused an out of bounds error when we were given less than 252 rows by the API.

To mitigate this edge case, we are defining the last_row index as:
`last_row = min(len(prices), _get_trading_days(period)) - 1`

Fixes #30 