### PR TITLE
feat: add portfolio report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,24 +7,21 @@ build:
 	mypy infra
 
 test:
-	cd src/ && python -m unittest discover
+	python -m unittest discover
 
 coverage:
 	rm -f .coverage
 	rm -f coverage.svg
-	cd src/ \
-		&& coverage run -m unittest discover \
-		&& mv .coverage ../ \
-		&& cd ../
+	coverage run -m unittest discover
 	coverage report
 	coverage html
 	coverage-badge -o coverage.svg
 
 poll:
-	python src/poll.py
+	python -m src.poll
 
 monitor:
-	python src/monitor.py
+	python -m src.monitor
 
 deploy:
 	cd infra && cdk deploy

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">96%</text>
-        <text x="80" y="14">96%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
+        <text x="80" y="14">95%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
-        <text x="80" y="14">95%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">99%</text>
+        <text x="80" y="14">99%</text>
     </g>
 </svg>

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -18,7 +18,7 @@ it will notify only about the 12-month limit. The 6-month, 3-month and 1-month
 minimum price has also been crossed, but we don't need to send notifications for
 them.
 
-This task executes automatically from Monday to Friday at 1800 GMT-4.
+This task executes automatically from Monday to Friday at 1800 GMT-5.
 (After the US stock market has closed).
 
 ### Notification

--- a/infra/monitor_service.py
+++ b/infra/monitor_service.py
@@ -23,7 +23,7 @@ class MonitorService(Construct):
             function_name='StockbotMonitor',
             code=aws_lambda.DockerImageCode.from_image_asset(
                 directory='../src',
-                cmd=['monitor.lambda_handler'],
+                cmd=['src.monitor.lambda_handler'],
             ),
             timeout=Duration.minutes(10),
             environment={

--- a/infra/monitor_service.py
+++ b/infra/monitor_service.py
@@ -33,14 +33,14 @@ class MonitorService(Construct):
             },
         )
 
-        # Execute rule from Monday to Friday at 2200 UTC (1800 GMT-4)
-        six_pm_utc = '22'
+        # Execute rule from Monday to Friday at 2300 UTC (1800 GMT-5)
+        utc_hour = '23'
         event_rule = aws_events.Rule(
             scope=self,
             id='StockbotMonitorRule',
             schedule=aws_events.Schedule.cron(
                 minute='0',
-                hour=six_pm_utc,
+                hour=utc_hour,
                 week_day='MON-FRI'
             ),
         )

--- a/infra/push_service.py
+++ b/infra/push_service.py
@@ -17,7 +17,7 @@ class PushService(Construct):
             function_name='StockbotPush',
             code=aws_lambda.DockerImageCode.from_image_asset(
                 directory='../src',
-                cmd=['push.lambda_handler'],
+                cmd=['src.push.lambda_handler'],
             ),
             timeout=Duration.seconds(30),  # Default is only 3 seconds
             environment={

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,9 +1,8 @@
 FROM public.ecr.aws/lambda/python:3.9
 
-# Copy function code
-COPY . ${LAMBDA_TASK_ROOT}
+# Copy code
+COPY . ${LAMBDA_TASK_ROOT}/src
 
 # Install the function's dependencies using file requirements.txt
 # from our project folder.
-COPY requirements.txt  .
-RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+RUN  pip3 install -r src/requirements.txt --target "${LAMBDA_TASK_ROOT}"

--- a/src/analyst/analyst.py
+++ b/src/analyst/analyst.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 from pandas import DataFrame
 
-from common.constants import DECIMAL_PLACES
-from common.types import (
+from src.common.constants import DECIMAL_PLACES
+from src.common.types import (
     Period,
     AnnualStats,
     ClosePrice,

--- a/src/analyst/analyst.py
+++ b/src/analyst/analyst.py
@@ -94,7 +94,8 @@ def _get_price_stats_in_period(prices: DataFrame, period: Period) -> PriceStats:
                       max_negative_change, max_positive_change)
 
 
-def _get_price_difference(a_price: ClosePrice, other_price: ClosePrice) -> float:
+def _get_price_difference(a_price: ClosePrice,
+                          other_price: ClosePrice) -> float:
     if a_price.date <= other_price.date:
         initial, final = a_price, other_price
     else:

--- a/src/analyst/analyst.py
+++ b/src/analyst/analyst.py
@@ -61,6 +61,20 @@ def get_price_anomaly(prices: DataFrame) -> Optional[PriceAnomaly]:
     return None
 
 
+def get_symbol_report(symbol: str, prices: DataFrame) -> SymbolReport:
+    return SymbolReport(
+        symbol=symbol,
+        current_price=get_current_price(prices).value,
+        week=_get_report_in_period(prices, Period.WEEK),
+        two_weeks=_get_report_in_period(prices, Period.TWO_WEEKS),
+        three_weeks=_get_report_in_period(prices, Period.THREE_WEEKS),
+        month=_get_report_in_period(prices, Period.MONTH),
+        quarter=_get_report_in_period(prices, Period.QUARTER),
+        half=_get_report_in_period(prices, Period.HALF),
+        year=_get_report_in_period(prices, Period.YEAR),
+    )
+
+
 # -----------------------------------------------------------------------------
 # private methods
 # -----------------------------------------------------------------------------
@@ -116,20 +130,6 @@ def _get_max_price(prices: DataFrame, period: Period) -> ClosePrice:
     row_id = prices.Close[:trading_days].idxmax()
     row = prices.iloc[row_id]
     return ClosePrice(row.Date, row.Close)
-
-
-def get_symbol_report(symbol: str, prices: DataFrame) -> SymbolReport:
-    return SymbolReport(
-        symbol=symbol,
-        current_price=get_current_price(prices).value,
-        week=_get_report_in_period(prices, Period.WEEK),
-        two_weeks=_get_report_in_period(prices, Period.TWO_WEEKS),
-        three_weeks=_get_report_in_period(prices, Period.THREE_WEEKS),
-        month=_get_report_in_period(prices, Period.MONTH),
-        quarter=_get_report_in_period(prices, Period.QUARTER),
-        half=_get_report_in_period(prices, Period.HALF),
-        year=_get_report_in_period(prices, Period.YEAR),
-    )
 
 
 def _get_volatility_in_period(prices: DataFrame, period: Period) -> float:

--- a/src/analyst/test_analyst.py
+++ b/src/analyst/test_analyst.py
@@ -3,8 +3,8 @@ from unittest.mock import patch
 
 import pandas as pd
 
-from analyst import analyst
-from common.types import PriceStats, ClosePrice, PriceAnomaly, Period
+from src.analyst import analyst
+from src.common.types import PriceStats, ClosePrice, PriceAnomaly, Period
 
 
 class AnalystTests(unittest.TestCase):
@@ -15,7 +15,8 @@ class AnalystTests(unittest.TestCase):
         the file: csv_files/stock-monitor-example-AMZN.ods
         """
         # arrange
-        expected_df = pd.read_csv('analyst/test_files/AMZN_from_stockbot.csv')
+        expected_df = pd.read_csv(
+            'src/analyst/test_files/AMZN_from_stockbot.csv')
         # act
         return_stats = analyst.get_return_stats(expected_df).round()
         # assert
@@ -31,7 +32,7 @@ class AnalystTests(unittest.TestCase):
         the file: csv_files/stock-monitor-example-AMZN.ods
         """
         # arrange
-        prices = pd.read_csv('analyst/test_files/AMZN_from_stockbot.csv')
+        prices = pd.read_csv('src/analyst/test_files/AMZN_from_stockbot.csv')
         # act
         price_stats = analyst.get_price_stats(prices)
         # assert
@@ -55,7 +56,7 @@ class AnalystTests(unittest.TestCase):
         the file: csv_files/stock-monitor-example-AMZN.ods
         """
         # arrange
-        prices = pd.read_csv('analyst/test_files/AMZN_from_stockbot.csv')
+        prices = pd.read_csv('src/analyst/test_files/AMZN_from_stockbot.csv')
         # act
         volatility = analyst.get_volatility_stats(prices)
         # assert
@@ -65,13 +66,13 @@ class AnalystTests(unittest.TestCase):
         self.assertEqual(volatility.half, 0.3995)
         self.assertEqual(volatility.year, 0.4350)
 
-    @patch('analyst.analyst.get_current_price')
+    @patch('src.analyst.analyst.get_current_price')
     def test_get_price_anomaly_return_year_anomaly(self, get_current_price):
         # arrange
         current_price = ClosePrice('2022-07-29', 1.0)
         # expected_price is less than the min price of the last year
         get_current_price.return_value = current_price
-        prices = pd.read_csv('analyst/test_files/AMZN_from_stockbot.csv')
+        prices = pd.read_csv('src/analyst/test_files/AMZN_from_stockbot.csv')
         # act
         anomaly = analyst.get_price_anomaly(prices)
         # assert
@@ -79,13 +80,13 @@ class AnalystTests(unittest.TestCase):
         self.assertEqual(
             anomaly.round(), self._get_expected_year_price_alert(current_price))
 
-    @patch('analyst.analyst.get_current_price')
+    @patch('src.analyst.analyst.get_current_price')
     def test_get_price_anomaly_return_month_anomaly(self, get_current_price):
         # arrange
         current_price = ClosePrice('2022-07-29', 104.0)
         # expected_price is less than the min price of the last month
         get_current_price.return_value = current_price
-        prices = pd.read_csv('analyst/test_files/AMZN_from_stockbot.csv')
+        prices = pd.read_csv('src/analyst/test_files/AMZN_from_stockbot.csv')
         # act
         anomaly = analyst.get_price_anomaly(prices)
         # assert
@@ -93,13 +94,13 @@ class AnalystTests(unittest.TestCase):
         self.assertEqual(
             anomaly.round(), self._get_expected_month_price_alert(current_price))
 
-    @patch('analyst.analyst.get_current_price')
+    @patch('src.analyst.analyst.get_current_price')
     def test_get_price_anomaly_return_none(self, get_current_price):
         # arrange
         expected_price = ClosePrice('2022-07-29', 120.0)
         # expected_price is within min and max of the last year
         get_current_price.return_value = expected_price
-        prices = pd.read_csv('analyst/test_files/AMZN_from_stockbot.csv')
+        prices = pd.read_csv('src/analyst/test_files/AMZN_from_stockbot.csv')
         # act
         anomaly = analyst.get_price_anomaly(prices)
         # assert

--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -66,7 +66,8 @@ class Bot:
 
             current_price = analyst.get_current_price(prices)
             return_stats = analyst.get_return_stats(prices)
-            readable_return_stats = formatter.human_readable_annual_stats(return_stats)
+            readable_return_stats = formatter.human_readable_annual_stats(
+                return_stats)
             message = (f'The return of {symbol.upper()} is:\n\n'
                        f'Current price:\n'
                        f'{formatter.as_decimal(current_price.value)} ({current_price.date})\n\n'
@@ -84,7 +85,8 @@ class Bot:
 
             current_price = analyst.get_current_price(prices)
             volatility_stats = analyst.get_volatility_stats(prices)
-            readable_volatility_stats = formatter.human_readable_annual_stats(volatility_stats)
+            readable_volatility_stats = formatter.human_readable_annual_stats(
+                volatility_stats)
             message = (f'The volatility of {symbol.upper()} is:\n\n'
                        f'Current price:\n'
                        f'{formatter.as_decimal(current_price.value)} ({current_price.date})\n\n'
@@ -104,7 +106,8 @@ class Bot:
             price_stats = analyst.get_price_stats(prices)
             return_stats = analyst.get_return_stats(prices)
             volatility_stats = analyst.get_volatility_stats(prices)
-            readable_all_stats = formatter.human_readable_all_annual_stats(price_stats, return_stats, volatility_stats)
+            readable_all_stats = formatter.human_readable_all_annual_stats(
+                price_stats, return_stats, volatility_stats)
             message = (f'The stats of {symbol.upper()} are:\n\n'
                        f'Current price:\n'
                        f'{formatter.as_decimal(current_price.value)} ({current_price.date})\n\n'
@@ -121,7 +124,8 @@ class Bot:
             prices = self.downloader.get_stock_historical_data(symbol)
             price_anomaly = analyst.get_price_anomaly(prices)
             if price_anomaly:
-                message = formatter.human_readable_price_anomaly(symbol, price_anomaly)
+                message = formatter.human_readable_price_anomaly(symbol,
+                                                                 price_anomaly)
                 messages.append(message)
 
         if not messages:

--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -1,9 +1,9 @@
 from pandas import DataFrame
 
-import bot.text_formatter as formatter
-from analyst import analyst
-from common import logs
-from download.download import Download
+import src.bot.text_formatter as formatter
+from src.analyst import analyst
+from src.common import logs
+from src.download.download import Download
 
 logger = logs.get_logger(__name__)
 

--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -129,6 +129,14 @@ class Bot:
 
         return messages
 
+    def report_portfolio(self, portfolio: list[str]) -> str:
+        report = ["Portfolio report\n"]
+        for symbol in portfolio:
+            prices = self.downloader.get_stock_historical_data(symbol)
+            symbol_report = analyst.get_symbol_report(symbol, prices)
+            report.append(formatter.human_readable_report(symbol_report))
+        return ''.join(report)
+
     # private methods
 
     @staticmethod

--- a/src/bot/test_bot.py
+++ b/src/bot/test_bot.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pandas as pd
 
-from bot.bot import Bot
+from src.bot.bot import Bot
 
 
 class BotTests(unittest.TestCase):
@@ -15,7 +15,8 @@ class BotTests(unittest.TestCase):
 
     def test_reply_start_success_get_expected_message(self):
         # arrange
-        expected_message = Path('bot/test_files/start.txt').read_text().rstrip()
+        expected_message = Path(
+            'src/bot/test_files/start.txt').read_text().rstrip()
         # act
         message = self.bot.reply_start()
         # assert
@@ -23,7 +24,8 @@ class BotTests(unittest.TestCase):
 
     def test_reply_help_success_get_expected_message(self):
         # arrange
-        expected_message = Path('bot/test_files/help.txt').read_text().rstrip()
+        expected_message = Path(
+            'src/bot/test_files/help.txt').read_text().rstrip()
         # act
         message = self.bot.reply_help()
         # assert
@@ -58,7 +60,8 @@ class BotTests(unittest.TestCase):
         # arrange
         text = '/price amzn'
         self._mock_downloader_to_get_historical_data()
-        expected_message = Path('bot/test_files/price.txt').read_text().rstrip()
+        expected_message = Path(
+            'src/bot/test_files/price.txt').read_text().rstrip()
         # act
         message = self.bot.reply_price_stats(text)
         # assert
@@ -95,7 +98,8 @@ class BotTests(unittest.TestCase):
         # arrange
         text = '/return amzn'
         self._mock_downloader_to_get_historical_data()
-        expected_message = Path('bot/test_files/return.txt').read_text().rstrip()
+        expected_message = Path(
+            'src/bot/test_files/return.txt').read_text().rstrip()
         # act
         message = self.bot.reply_return_stats(text)
         # assert
@@ -132,7 +136,8 @@ class BotTests(unittest.TestCase):
         # arrange
         text = '/vol amzn'
         self._mock_downloader_to_get_historical_data()
-        expected_message = Path('bot/test_files/volatility.txt').read_text().rstrip()
+        expected_message = Path(
+            'src/bot/test_files/volatility.txt').read_text().rstrip()
         # act
         message = self.bot.reply_volatility_stats(text)
         # assert
@@ -169,7 +174,8 @@ class BotTests(unittest.TestCase):
         # arrange
         text = '/all amzn'
         self._mock_downloader_to_get_historical_data()
-        expected_message = Path('bot/test_files/all.txt').read_text().rstrip()
+        expected_message = Path(
+            'src/bot/test_files/all.txt').read_text().rstrip()
         # act
         message = self.bot.reply_all_stats(text)
         # assert
@@ -180,8 +186,10 @@ class BotTests(unittest.TestCase):
     # region private methods
 
     def _mock_downloader_to_get_historical_data(self):
-        expected_df = pd.read_csv('analyst/test_files/AMZN_from_stockbot.csv')
-        self.downloader_mock.get_stock_historical_data = MagicMock(return_value=expected_df)
+        expected_df = pd.read_csv(
+            'src/analyst/test_files/AMZN_from_stockbot.csv')
+        self.downloader_mock.get_stock_historical_data = MagicMock(
+            return_value=expected_df)
 
     def _mock_downloader_to_get_empty_historical_data(self):
         expected_df = pd.DataFrame([])

--- a/src/bot/test_bot.py
+++ b/src/bot/test_bot.py
@@ -183,6 +183,60 @@ class BotTests(unittest.TestCase):
 
     # endregion
 
+    # region monitor portfolio
+
+    def test_monitor_portfolio_success_no_new_price_alerts(self):
+        portfolio = []
+        self._mock_downloader_to_get_historical_data()
+        messages = self.bot.monitor_portfolio(portfolio)
+        # assert
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0], 'No new price alerts for today')
+
+    def test_monitor_portfolio_success_three_new_price_alerts(self):
+        portfolio = ['AMZN']
+        self._mock_downloader_to_get_historical_data()
+        messages = self.bot.monitor_portfolio(portfolio)
+        # assert
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(
+            messages[0],
+            ('Price alert for AMZN:\n'
+             'New 3mo Max price: 134.95 (2022-07-29)\n'
+             'Old 3mo values: Min: 102.31 (2022-06-14), Max: 134.95 (2022-07-29)')
+        )
+
+    # endregion
+
+    # region report portfolio
+
+    def test_report_portfolio_success_empty_report(self):
+        portfolio = []
+        self._mock_downloader_to_get_historical_data()
+        report = self.bot.report_portfolio(portfolio)
+        # assert
+        self.assertEqual(report, 'Portfolio report\n')
+
+    def test_report_portfolio_success_non_empty_report(self):
+        portfolio = ['AMZN']
+        self._mock_downloader_to_get_historical_data()
+        report = self.bot.report_portfolio(portfolio)
+        # assert
+        self.assertEqual(
+            report,
+            ('Portfolio report\n\n'
+            'AMZN price: 134.95\n'
+            '1wk: 10.24%\n'
+            '2wk: 18.85%\n'
+            '3wk: 16.80%\n'
+            '1mo: 23.90%\n'
+            '3mo: 8.58%\n'
+            '6mo: -6.27%\n'
+            '12mo: -18.89%\n')
+        )
+
+    # endregion
+
     # region private methods
 
     def _mock_downloader_to_get_historical_data(self):

--- a/src/bot/test_bot.py
+++ b/src/bot/test_bot.py
@@ -193,6 +193,7 @@ class BotTests(unittest.TestCase):
 
     def _mock_downloader_to_get_empty_historical_data(self):
         expected_df = pd.DataFrame([])
-        self.downloader_mock.get_stock_historical_data = MagicMock(return_value=expected_df)
+        self.downloader_mock.get_stock_historical_data = MagicMock(
+            return_value=expected_df)
 
     # endregion

--- a/src/bot/text_formatter.py
+++ b/src/bot/text_formatter.py
@@ -27,7 +27,7 @@ def human_readable_annual_stats(annual_stats: AnnualStats) -> str:
 
 def human_readable_all_annual_stats(price_stats: AnnualPriceStats,
                                     return_stats: AnnualStats,
-                                    volatility_stats: AnnualStats):
+                                    volatility_stats: AnnualStats) -> str:
     result = _human_readable_price_stats(Period.MONTH, price_stats.month)
     result += f'return: {as_percentage(return_stats.month)}\n'
     result += f'volatility: {as_percentage(volatility_stats.month)}\n'
@@ -47,7 +47,7 @@ def human_readable_all_annual_stats(price_stats: AnnualPriceStats,
     return result
 
 
-def human_readable_price_anomaly(symbol, price_anomaly: PriceAnomaly):
+def human_readable_price_anomaly(symbol, price_anomaly: PriceAnomaly) -> str:
     min_or_max = 'Min' if price_anomaly.is_new_min() else 'Max'
     return (
         f'Price alert for {symbol}:\n'

--- a/src/bot/text_formatter.py
+++ b/src/bot/text_formatter.py
@@ -1,5 +1,6 @@
-from common.types import (
-    Period, PriceStats, AnnualStats, AnnualPriceStats, PriceAnomaly
+from src.common.types import (
+    Period, PriceStats, AnnualStats, AnnualPriceStats, PriceAnomaly,
+    SymbolReport
 )
 
 
@@ -56,6 +57,19 @@ def human_readable_price_anomaly(symbol, price_anomaly: PriceAnomaly):
         f'Old {price_anomaly.period} values:'
         f' Min: {as_decimal(price_anomaly.min_price.value)} ({price_anomaly.min_price.date}),'
         f' Max: {as_decimal(price_anomaly.max_price.value)} ({price_anomaly.max_price.date})'
+    )
+
+
+def human_readable_report(symbol_report: SymbolReport) -> str:
+    return (
+        f'\n{symbol_report.symbol} price: {as_decimal(symbol_report.current_price)}\n'
+        f'{symbol_report.week.period}: {as_percentage(symbol_report.week.change_in_period)}\n'
+        f'{symbol_report.two_weeks.period}: {as_percentage(symbol_report.two_weeks.change_in_period)}\n'
+        f'{symbol_report.three_weeks.period}: {as_percentage(symbol_report.three_weeks.change_in_period)}\n'
+        f'{symbol_report.month.period}: {as_percentage(symbol_report.month.change_in_period)}\n'
+        f'{symbol_report.quarter.period}: {as_percentage(symbol_report.quarter.change_in_period)}\n'
+        f'{symbol_report.half.period}: {as_percentage(symbol_report.half.change_in_period)}\n'
+        f'{symbol_report.year.period}: {as_percentage(symbol_report.year.change_in_period)}\n'
     )
 
 

--- a/src/commands.py
+++ b/src/commands.py
@@ -4,8 +4,8 @@ from telegram.ext import (
     CallbackContext, CommandHandler, MessageHandler, Filters, Dispatcher
 )
 
-from bot.bot import Bot
-from download.download import Download
+from src.bot.bot import Bot
+from src.download.download import Download
 
 downloader = Download(yf)
 bot = Bot(downloader)

--- a/src/common/test_types.py
+++ b/src/common/test_types.py
@@ -3,7 +3,7 @@ import unittest
 
 import pandas as pd
 
-from common.types import ClosePrice
+from src.common.types import ClosePrice
 
 
 class TypesTests(unittest.TestCase):

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -9,6 +9,9 @@ from src.common.constants import DECIMAL_PLACES
 
 
 class Period(str, Enum):
+    WEEK = '1wk'
+    TWO_WEEKS = '2wk'
+    THREE_WEEKS = '3wk'
     MONTH = '1mo'
     QUARTER = '3mo'
     HALF = '6mo'
@@ -121,3 +124,22 @@ class PriceAnomaly(NamedTuple):
     def __str__(self) -> str:
         return f'{self.period}, {self.min_price.value}, ' \
                f'{self.current_price.value}, {self.max_price.value}'
+
+
+class ReportInPeriod(NamedTuple):
+    period: Period
+    min_price: ClosePrice
+    max_price: ClosePrice
+    change_in_period: float
+
+
+class SymbolReport(NamedTuple):
+    symbol: str
+    current_price: float
+    week: ReportInPeriod
+    two_weeks: ReportInPeriod
+    three_weeks: ReportInPeriod
+    month: ReportInPeriod
+    quarter: ReportInPeriod
+    half: ReportInPeriod
+    year: ReportInPeriod

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 
 import pandas as pd
 
-from common.constants import DECIMAL_PLACES
+from src.common.constants import DECIMAL_PLACES
 
 
 class Period(str, Enum):

--- a/src/download/download.py
+++ b/src/download/download.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pandas import DataFrame
 
-from common.types import Period
+from src.common.types import Period
 
 
 class Download:

--- a/src/download/test_download.py
+++ b/src/download/test_download.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pandas as pd
 import yfinance as yf
 
-from download.download import Download
+from src.download.download import Download
 
 
 class DownloadTests(unittest.TestCase):
@@ -24,7 +24,7 @@ class DownloadTests(unittest.TestCase):
 
     @staticmethod
     def _get_mocked_yfinance():
-        expected_df = pd.read_csv('download/test_files/AMZN_from_yfinance.csv')
+        expected_df = pd.read_csv('src/download/test_files/AMZN_from_yfinance.csv')
         mocked_ticker = MagicMock()
         mocked_ticker.history = MagicMock(return_value=expected_df)
         yf.Ticker = MagicMock(return_value=mocked_ticker)

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -44,8 +44,7 @@ def _monitor(portfolio: list[str]) -> None:
 
 def _report(portfolio: list[str]) -> None:
     message = bot.report_portfolio(portfolio)
-    logger.info(f'_report: message length: {len(message)}')
-    logger.info(f'_report: message: {message}')
+    logger.info(f'_report: {message}')
     telegram.send_message(channel_id, message)
 
 

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -3,10 +3,11 @@ Monitor
 """
 import yfinance as yf
 from telegram import Bot as TelegramBot
+import telegram as tl
 
-from bot.bot import Bot
-from common import env_validator, logs
-from download.download import Download
+from src.bot.bot import Bot
+from src.common import env_validator, logs
+from src.download.download import Download
 
 logger = logs.get_logger(__name__)
 

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -25,6 +25,7 @@ bot = Bot(downloader)
 def lambda_handler(event, context):
     try:
         _monitor(portfolio)
+        _report(portfolio)
         return {"statusCode": 200}
     except Exception as e:
         logger.error(e)
@@ -39,6 +40,13 @@ def _monitor(portfolio: list[str]) -> None:
     for message in messages:
         logger.info(message)
         telegram.send_message(channel_id, message)
+
+
+def _report(portfolio: list[str]) -> None:
+    message = bot.report_portfolio(portfolio)
+    logger.info(f'_report: message length: {len(message)}')
+    logger.info(f'_report: message: {message}')
+    telegram.send_message(channel_id, message)
 
 
 if __name__ == '__main__':

--- a/src/poll.py
+++ b/src/poll.py
@@ -4,8 +4,8 @@ Poll mode: the bot polls Telegram from new messages.
 """
 from telegram.ext import Updater, Dispatcher
 
-import commands
-from common import env_validator
+import src.commands as commands
+from src.common import env_validator
 
 
 def poll() -> None:

--- a/src/push.py
+++ b/src/push.py
@@ -7,8 +7,8 @@ import json
 from telegram import Update, Bot as TelegramBot
 from telegram.ext import Dispatcher
 
-import commands
-from common import env_validator, logs
+import src.commands as commands
+from src.common import env_validator, logs
 
 logger = logs.get_logger(__name__)
 


### PR DESCRIPTION
Add support for sending a portfolio report every weekday at 1800 ET.

The report sent looks like this:

```
AAPL (current price)
1wk: X%
2wk: X%
3wk: X%
1mo: X%
2mo: X%
3mo: X%
6mo: X%
12mo: X%
```

Fixes #33 

Other changes in this PR:

1. fix the usage of absolute imports.
2. exceute the monitor at 1800 GMT-5